### PR TITLE
Fix to mitigate the curses app error when curation script is triggered by jenkins.

### DIFF
--- a/docker_benchmarking/curated_apps_lib.py
+++ b/docker_benchmarking/curated_apps_lib.py
@@ -50,10 +50,10 @@ def generate_curated_image(test_config_dict):
     curation_output = ''
     workload_image = test_config_dict["docker_image"]
 
-    curation_cmd = 'python3 curate.py ' + workload_image + ' test'
+    # The following ssh command is to mitigate the curses error faced while launching the command through Jenkins.
+    curation_cmd = f"sshpass -e ssh -tt intel@localhost 'cd {CURATED_APPS_PATH} && python3 curate.py {workload_image} test'"
     
     print("Curation cmd ", curation_cmd)
-    os.chdir(CURATED_APPS_PATH)
     result = subprocess.run([curation_cmd], input=b'\x07', shell=True, check=True, stdout=subprocess.PIPE)
     os.chdir(FRAMEWORK_HOME_DIR)
       


### PR DESCRIPTION
This fix works for both when the framework is executed either via standalone or via jenkins.

Signed-off-by: Vasanth Nagaraja <vasanth.k.nagaraja@intel.com>