### PR TITLE
Use median as average calculation for exec modes.

### DIFF
--- a/baremetal_benchmarking/config_files/python_packages.yaml
+++ b/baremetal_benchmarking/config_files/python_packages.yaml
@@ -4,6 +4,8 @@
 Default:
  asv>=0.5.1
  "meson >=0.56, <0.57"
+ "tomli>=1.1.0"
+ "tomli-w>=0.4.0"
  openpyxl
 
 "18.04":

--- a/baremetal_benchmarking/workloads/openvino_workload.py
+++ b/baremetal_benchmarking/workloads/openvino_workload.py
@@ -1,5 +1,6 @@
 import time
 import shutil
+import statistics
 from pathlib import Path
 from common.config_files.constants import *
 from common.libs import utils
@@ -250,16 +251,15 @@ class OpenvinoWorkload():
     def update_test_results_in_global_dict(self, tcd, test_dict):
         global trd
         if 'native' in tcd['exec_mode']:
-            test_dict['native-avg'] = '{:0.3f}'.format(sum(test_dict['native'])/len(test_dict['native']))
+            test_dict['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict['native']))
 
         if 'gramine-direct' in tcd['exec_mode']:
-            test_dict['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict['gramine-direct'])/len(test_dict['gramine-direct']))
+            test_dict['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict['gramine-direct']))
             if 'native' in tcd['exec_mode']:
                 test_dict['direct-deg'] = utils.percent_degradation(tcd, test_dict['native-avg'], test_dict['direct-avg'])
 
         if 'gramine-sgx' in tcd['exec_mode']:
-            test_dict['sgx-avg'] = '{:0.3f}'.format(sum(test_dict['gramine-sgx'])/len(test_dict['gramine-sgx']))
+            test_dict['sgx-avg'] = '{:0.3f}'.format(statistics.median(test_dict['gramine-sgx']))
             if 'native' in tcd['exec_mode']:
                 test_dict['sgx-deg'] = utils.percent_degradation(tcd, test_dict['native-avg'], test_dict['sgx-avg'])
 

--- a/baremetal_benchmarking/workloads/redis_workload.py
+++ b/baremetal_benchmarking/workloads/redis_workload.py
@@ -1,6 +1,7 @@
 import time
 import shutil
 import glob
+import statistics
 from common.config_files.constants import *
 from baremetal_benchmarking import gramine_libs
 from common.libs import utils
@@ -222,32 +223,26 @@ class RedisWorkload:
                     test_dict_throughput['gramine-direct'].append(float(avg_throughput))
 
         if 'native' in tcd['exec_mode']:
-            test_dict_latency['native-avg'] = '{:0.3f}'.format(sum(test_dict_latency['native'])/len(test_dict_latency['native']))
-            test_dict_throughput['native-avg'] = '{:0.3f}'.format(sum(test_dict_throughput['native'])/len(test_dict_throughput['native']))
+            test_dict_latency['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['native']))
+            test_dict_throughput['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['native']))
 
         if 'gramine-direct' in tcd['exec_mode']:
-            test_dict_latency['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-direct'])/len(test_dict_latency['gramine-direct']))
-            test_dict_throughput['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-direct'])/len(test_dict_throughput['gramine-direct']))
+            test_dict_latency['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-direct']))
+            test_dict_throughput['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-direct']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['direct-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['direct-avg'])
                 test_dict_throughput['direct-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['direct-avg'], True)
 
         if 'gramine-sgx-single-thread-non-exitless' in tcd['exec_mode']:
-            test_dict_latency['sgx-single-thread-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-sgx-single-thread-non-exitless'])/len(test_dict_latency['gramine-sgx-single-thread-non-exitless']))
-            test_dict_throughput['sgx-single-thread-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-sgx-single-thread-non-exitless'])/len(test_dict_throughput['gramine-sgx-single-thread-non-exitless']))
+            test_dict_latency['sgx-single-thread-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-sgx-single-thread-non-exitless']))
+            test_dict_throughput['sgx-single-thread-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-sgx-single-thread-non-exitless']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['sgx-single-thread-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['sgx-single-thread-avg'])
                 test_dict_throughput['sgx-single-thread-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['sgx-single-thread-avg'], True)
 
         if 'gramine-sgx-diff-core-exitless' in tcd['exec_mode']:
-            test_dict_latency['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-sgx-diff-core-exitless'])/len(test_dict_latency['gramine-sgx-diff-core-exitless']))
-            test_dict_throughput['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-sgx-diff-core-exitless'])/len(test_dict_throughput['gramine-sgx-diff-core-exitless']))
+            test_dict_latency['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-sgx-diff-core-exitless']))
+            test_dict_throughput['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-sgx-diff-core-exitless']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['sgx-diff-core-exitless-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['sgx-diff-core-exitless-avg'])
                 test_dict_throughput['sgx-diff-core-exitless-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['sgx-diff-core-exitless-avg'], True)

--- a/baremetal_benchmarking/workloads/tensorflow_workload.py
+++ b/baremetal_benchmarking/workloads/tensorflow_workload.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import re
+import statistics
 from common.config_files.constants import *
 from common.libs import utils
 from baremetal_benchmarking import gramine_libs
@@ -198,16 +199,15 @@ class TensorflowWorkload():
     def update_test_results_in_global_dict(self, tcd, test_dict):
         global trd
         if 'native' in tcd['exec_mode']:
-            test_dict['native-avg'] = '{:0.3f}'.format(sum(test_dict['native'])/len(test_dict['native']))
+            test_dict['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict['native']))
 
         if 'gramine-direct' in tcd['exec_mode']:
-            test_dict['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict['gramine-direct'])/len(test_dict['gramine-direct']))
+            test_dict['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict['gramine-direct']))
             if 'native' in tcd['exec_mode']:
                 test_dict['direct-deg'] = utils.percent_degradation(tcd, test_dict['native-avg'], test_dict['direct-avg'])
 
         if 'gramine-sgx' in tcd['exec_mode']:
-            test_dict['sgx-avg'] = '{:0.3f}'.format(sum(test_dict['gramine-sgx'])/len(test_dict['gramine-sgx']))
+            test_dict['sgx-avg'] = '{:0.3f}'.format(statistics.median(test_dict['gramine-sgx']))
             if 'native' in tcd['exec_mode']:
                 test_dict['sgx-deg'] = utils.percent_degradation(tcd, test_dict['native-avg'], test_dict['sgx-avg'])
 

--- a/common/libs/utils.py
+++ b/common/libs/utils.py
@@ -70,8 +70,12 @@ def clean_up_system():
     dentries, inodes and apt cache.
     :return:
     """
-    print("\n-- Removing unnecessary packages and dependencies..")
-    exec_shell_cmd("sudo apt-get -y autoremove", None)
+    try:
+        print("\n-- Removing unnecessary packages and dependencies..")
+        exec_shell_cmd("sudo apt-get -y autoremove", None)
+    except:
+        print("\n-- Executing apt --fix-broken cmd..\n", APT_FIX_BROKEN_CMD)
+        exec_shell_cmd(APT_FIX_BROKEN_CMD, None)
     print("\n-- Clearing thumbnail cache..")
     exec_shell_cmd("sudo rm -rf ~/.cache/thumbnails/*", None)
     print("\n-- Clearing apt cache..")
@@ -167,6 +171,12 @@ def update_env_variables(build_prefix):
         print(f"\n-- PYTHONPATH command\n", PYTHONPATH_CMD)
         os.environ["PYTHONPATH"] = exec_shell_cmd(PYTHONPATH_CMD)
         print(f"\n-- Updated environment PYTHONPATH variable to the following..\n", os.environ["PYTHONPATH"])
+
+    print(f"\n-- Updating 'LC_ALL' env-var\n")
+    os.environ['LC_ALL'] = "C.UTF-8"
+
+    print(f"\n-- Updating 'LANG' env-var\n")
+    os.environ['LANG'] = "C.UTF-8"
 
     print(f"\n-- Updating 'SSHPASS' env-var\n")
     os.environ['SSHPASS'] = "intel@123"

--- a/docker_benchmarking/workloads/redis_workload.py
+++ b/docker_benchmarking/workloads/redis_workload.py
@@ -1,5 +1,6 @@
 import time
 import glob
+import statistics
 from common.config_files.constants import *
 from docker_benchmarking import curated_apps_lib
 from common.libs import utils
@@ -190,32 +191,26 @@ class RedisWorkload:
                     test_dict_throughput['gramine-direct'].append(float(avg_throughput))
 
         if 'native' in tcd['exec_mode']:
-            test_dict_latency['native-avg'] = '{:0.3f}'.format(sum(test_dict_latency['native'])/len(test_dict_latency['native']))
-            test_dict_throughput['native-avg'] = '{:0.3f}'.format(sum(test_dict_throughput['native'])/len(test_dict_throughput['native']))
+            test_dict_latency['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['native']))
+            test_dict_throughput['native-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['native']))
 
         if 'gramine-direct' in tcd['exec_mode']:
-            test_dict_latency['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-direct'])/len(test_dict_latency['gramine-direct']))
-            test_dict_throughput['direct-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-direct'])/len(test_dict_throughput['gramine-direct']))
+            test_dict_latency['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-direct']))
+            test_dict_throughput['direct-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-direct']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['direct-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['direct-avg'])
                 test_dict_throughput['direct-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['direct-avg'], True)
 
         if 'gramine-sgx-single-thread-non-exitless' in tcd['exec_mode']:
-            test_dict_latency['sgx-single-thread-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-sgx-single-thread-non-exitless'])/len(test_dict_latency['gramine-sgx-single-thread-non-exitless']))
-            test_dict_throughput['sgx-single-thread-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-sgx-single-thread-non-exitless'])/len(test_dict_throughput['gramine-sgx-single-thread-non-exitless']))
+            test_dict_latency['sgx-single-thread-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-sgx-single-thread-non-exitless']))
+            test_dict_throughput['sgx-single-thread-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-sgx-single-thread-non-exitless']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['sgx-single-thread-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['sgx-single-thread-avg'])
                 test_dict_throughput['sgx-single-thread-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['sgx-single-thread-avg'], True)
 
         if 'gramine-sgx-diff-core-exitless' in tcd['exec_mode']:
-            test_dict_latency['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(
-                sum(test_dict_latency['gramine-sgx-diff-core-exitless'])/len(test_dict_latency['gramine-sgx-diff-core-exitless']))
-            test_dict_throughput['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(
-                sum(test_dict_throughput['gramine-sgx-diff-core-exitless'])/len(test_dict_throughput['gramine-sgx-diff-core-exitless']))
+            test_dict_latency['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(statistics.median(test_dict_latency['gramine-sgx-diff-core-exitless']))
+            test_dict_throughput['sgx-diff-core-exitless-avg'] = '{:0.3f}'.format(statistics.median(test_dict_throughput['gramine-sgx-diff-core-exitless']))
             if 'native' in tcd['exec_mode']:
                 test_dict_latency['sgx-diff-core-exitless-deg'] = utils.percent_degradation(tcd, test_dict_latency['native-avg'], test_dict_latency['sgx-diff-core-exitless-avg'])
                 test_dict_throughput['sgx-diff-core-exitless-deg'] = utils.percent_degradation(tcd, test_dict_throughput['native-avg'], test_dict_throughput['sgx-diff-core-exitless-avg'], True)


### PR DESCRIPTION
- Use median as average calculation for exec modes.. 
- Fix to mitigate the error faced during system cleanup. 
- Added the 'tomli-w' dependency within python_packages.yaml. 
- Finally, initialized env variables "LC_ALL" and "LANG", without which gramine sgx private key generation will fail.

Signed-off-by: Vasanth Nagaraja <vasanth.k.nagaraja@intel.com>