### PR TITLE
Enable memcached for bi-weekly perf runs

### DIFF
--- a/baremetal_benchmarking/config_files/memcached.manifest.template.non-exitless
+++ b/baremetal_benchmarking/config_files/memcached.manifest.template.non-exitless
@@ -27,7 +27,7 @@ fs.mounts = [
 
 sgx.debug = true
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
-sgx.max_threads = 16
+sgx.max_threads = 32
 
 # Memcached does not fail explicitly when enclave memory is exhausted. Instead, Memcached goes into
 # infinite loop without a listening socket. You can trigger this incorrect behavior by increasing

--- a/baremetal_benchmarking/config_files/system_packages.yaml
+++ b/baremetal_benchmarking/config_files/system_packages.yaml
@@ -90,7 +90,6 @@ Default:
  python3-recommonmark
  python3-sphinx-rtd-theme
  python3-toml
- python-is-python3
  sphinx-doc
  
 "21.04":
@@ -100,5 +99,4 @@ Default:
  python3-recommonmark
  python3-sphinx-rtd-theme
  python3-toml
- python-is-python3
  sphinx-doc

--- a/baremetal_benchmarking/workloads/sklearnex_workload.py
+++ b/baremetal_benchmarking/workloads/sklearnex_workload.py
@@ -37,6 +37,9 @@ class SklearnexWorkload():
             print("\n-- Executing pip upgrade command..")
             utils.exec_shell_cmd(PIP_UPGRADE_CMD)
         
+        if distro == 'ubuntu' and (distro_version == '20.04' or distro_version == '21.04'):
+            utils.exec_shell_cmd("sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python-is-python3", None)
+
         # Checking if the directory is empty or not
         if not os.listdir(self.workload_home_dir):
             print("\n-- Cloning scikit-learn benchmark..")

--- a/common/config_files/constants.py
+++ b/common/config_files/constants.py
@@ -38,7 +38,7 @@ GRAMINE_SGX_SED_CMD = "sed -i \"/uname/ a '/usr/src/linux-headers-@0@/arch/x86/i
 
 GRAMINE_BUILD_MESON_CMD = "meson setup build/ --werror " + \
                         BUILD_TYPE_PREFIX_STRING + \
-                        " -Ddirect=enabled -Dsgx=enabled -Dtests=enabled > " + \
+                        " -Ddirect=enabled -Dsgx=enabled > " + \
                         LOGS_DIR + "/gramine_build_meson_cmd_output.txt"
 
 GRAMINE_NINJA_BUILD_CMD = "ninja -vC build > " + LOGS_DIR + "/gramine_ninja_build_cmd_output.txt"

--- a/data/memcached_performance_tests.yaml
+++ b/data/memcached_performance_tests.yaml
@@ -35,5 +35,12 @@ test_memcached_perf_4096_data_size_1_1_rw_ratio:
 
 test_memcached_perf_4096_data_size_1_9_rw_ratio:
   data_size: 4096
-  rw_ratio: "1:9"  
+  rw_ratio: "1:9"
+
+test_memcached_perf_77824_data_size_1_1_rw_ratio:
+  data_size: 77824
+
+test_memcached_perf_77824_data_size_1_9_rw_ratio:
+  data_size: 77824
+  rw_ratio: "1:9"
   

--- a/tests/test_memcached_performance.py
+++ b/tests/test_memcached_performance.py
@@ -93,3 +93,19 @@ class TestClass:
 
         test_result = run_test(self, tests_yaml_path)
         assert test_result
+
+    @pytest.mark.memcached_perf
+    @pytest.mark.memcached_perf_77824_data_size
+    @pytest.mark.memcached_perf_77824_data_size_1_1_rw_ratio
+    def test_memcached_perf_77824_data_size_1_1_rw_ratio(self):
+
+        test_result = run_test(self, tests_yaml_path)
+        assert test_result
+
+    @pytest.mark.memcached_perf
+    @pytest.mark.memcached_perf_77824_data_size
+    @pytest.mark.memcached_perf_77824_data_size_1_9_rw_ratio
+    def test_memcached_perf_77824_data_size_1_9_rw_ratio(self):
+
+        test_result = run_test(self, tests_yaml_path)
+        assert test_result


### PR DESCRIPTION
Updating memcached workload to formally run within the bi-weekly perf runs.
Disabled Gramine Tests from being built within the meson command, to mitigate the compilation error from rwlock.c in Ubuntu 18.04.
Separated python-is-python3 installation from the system packages and installing only from the workload (sklearn).