### PR TITLE
Upgrading redis version to 7.0.0 for both baremetal and container workloads

### DIFF
--- a/baremetal_benchmarking/workloads/redis_workload.py
+++ b/baremetal_benchmarking/workloads/redis_workload.py
@@ -13,8 +13,8 @@ class RedisWorkload:
     def __init__(self, test_config_dict):
         # Redis home dir => "~/gramerf_framework/gramine/CI-Examples/redis"
         self.workload_home_dir = os.path.join(FRAMEWORK_HOME_DIR, test_config_dict['workload_home_dir'])
-        # Redis build dir => "~/gramerf_framework/gramine/CI-Examples/redis/redis-6.0.5"
-        self.workload_bld_dir = os.path.join(self.workload_home_dir, "redis-6.0.5")
+        # Redis build dir => "~/gramerf_framework/gramine/CI-Examples/redis/redis-7.0.0"
+        self.workload_bld_dir = os.path.join(self.workload_home_dir, "redis-7.0.0")
         self.server_ip_addr = utils.determine_host_ip_addr()
         self.command = None
 

--- a/common/config_files/constants.py
+++ b/common/config_files/constants.py
@@ -25,7 +25,7 @@ EXAMPLES_REPO_CLONE_CMD = "git clone https://github.com/gramineproject/examples.
 
 MIMALLOC_CLONE_CMD = "git clone -b v1.7.6 https://github.com/microsoft/mimalloc.git"
 
-REDIS_DOWNLOAD_CMD = "wget https://github.com/antirez/redis/archive/6.0.5.tar.gz"
+REDIS_DOWNLOAD_CMD = "wget https://github.com/antirez/redis/archive/7.0.0.tar.gz"
 
 MEMCACHED_DOWNLOAD_CMD = "wget https://memcached.org/files/memcached-1.5.21.tar.gz"
 

--- a/data/redis_performance_tests.yaml
+++ b/data/redis_performance_tests.yaml
@@ -14,7 +14,7 @@ Default:
   client_scripts_path: "/home/intel/perf_benchmarking/gramerf_redis_client"
   client_results_path: "/home/intel/perf_benchmarking/redis-6.0.6/log/set/"
   rw_ratio: "1:1"
-  docker_image: redis redis:6.0.5
+  docker_image: redis redis:7.0.0
   
 test_redis_perf_48_data_size_1_1_rw_ratio:
   data_size: 48


### PR DESCRIPTION
Upgrading redis version from 6.0.5 to to 7.0.0 for both baremetal and container workloads