### PR TITLE
Checkout gramine repo/commit - Curated/baremetal workloads

### DIFF
--- a/baremetal_benchmarking/gramine_libs.py
+++ b/baremetal_benchmarking/gramine_libs.py
@@ -21,20 +21,27 @@ def fresh_gramine_checkout():
     if os.path.exists(GRAMINE_HOME_DIR):
         shutil.rmtree(GRAMINE_HOME_DIR)
     
-    print("\n-- Cloning Gramine git repo..\n", GRAMINE_CLONE_CMD)
-    utils.exec_shell_cmd(GRAMINE_CLONE_CMD)
+    gramine_repo = os.environ['gramine_repo']
+    print(f"\n-- Cloning Gramine git repo: {gramine_repo}\n")
+    if gramine_repo != '':
+        utils.exec_shell_cmd(f"git clone {gramine_repo}", None)
+    else:
+        utils.exec_shell_cmd(GRAMINE_CLONE_CMD, None)
         
     # Git clone the examples repo too for workloads download.
     os.chdir(GRAMINE_HOME_DIR)
 
-    commit_id = os.environ["commit_id"]
-    if commit_id != '':
-        utils.exec_shell_cmd(f"git checkout {commit_id}")
+    gramine_commit = os.environ["gramine_commit"]
+    # If 'gramine_commit' is passed, corresponding gramine commit will be checked out
+    # to build gramine from source. If 'gramine_commit' is not specified, latest
+    # master will be used to build gramine.
+    if gramine_commit != '':
+        utils.exec_shell_cmd(f"git checkout {gramine_commit}", None)
     else:
-        commit_id = utils.exec_shell_cmd("git rev-parse HEAD")
-        os.environ["commit_id"] = commit_id
+        gramine_commit = utils.exec_shell_cmd("git rev-parse HEAD")
+        os.environ["gramine_commit"] = gramine_commit
 
-    print("\n-- Checked out following Gramine commit: ", commit_id)
+    print("\n-- Checked out following Gramine commit: ", gramine_commit)
 
     print("\n-- Cloning Gramine examples git repo..\n", EXAMPLES_REPO_CLONE_CMD)
     utils.exec_shell_cmd(EXAMPLES_REPO_CLONE_CMD)

--- a/common/config_files/constants.py
+++ b/common/config_files/constants.py
@@ -17,8 +17,9 @@ BUILD_PREFIX = FRAMEWORK_HOME_DIR + "/gramine_install/usr"
 # Commands constants
 GRAMINE_CLONE_CMD = "git clone https://github.com/gramineproject/gramine.git"
 
+GRAMINE_DEFAULT_REPO = "https://github.com/gramineproject/gramine.git"
 GRAMINE_CLONE = "RUN git clone --depth 1 --branch v1.5 https://github.com/gramineproject/gramine.git"
-DEPTH_STR = "--depth 1 --branch v1.5 "
+GRAMINE_DEPTH_STR  = "--depth 1 --branch v1.5 "
 GSC_CLONE          = "git clone --depth 1 --branch v1.5 https://github.com/gramineproject/gsc.git"
 GSC_DEPTH_STR      = "--depth 1 --branch v1.5 "
 EXAMPLES_REPO_CLONE_CMD = "git clone https://github.com/gramineproject/examples.git"

--- a/common/libs/utils.py
+++ b/common/libs/utils.py
@@ -349,11 +349,8 @@ def write_to_report(workload_name, test_results):
     now = dt.isoformat(dt.now()).replace(":","-").split('.')[0]
     if workload_name == 'Tensorflow' and os.environ['encryption'] == '1':
         workload_name = 'tensorflow_encrypted'
-    if os.environ['perf_config'] == "baremetal":
-        commit_id = os.environ["commit_id"]
-    else:
-        commit_id = os.environ["curation_commit"]
-    report_name = os.path.join(PERF_RESULTS_DIR, "gramine_" + workload_name.lower() + "_perf_data_" + os.environ["jenkins_build_num"] + "_" + now + "_" + commit_id[:7] + ".xlsx")
+    gramine_commit = os.environ["gramine_commit"]
+    report_name = os.path.join(PERF_RESULTS_DIR, "gramine_" + workload_name.lower() + "_perf_data_" + os.environ["jenkins_build_num"] + "_" + now + "_" + gramine_commit[:7] + ".xlsx")
     if not os.path.exists(PERF_RESULTS_DIR): os.makedirs(PERF_RESULTS_DIR)
     if os.path.exists(report_name):
         writer = pd.ExcelWriter(report_name, engine='openpyxl', mode='a')

--- a/conftest.py
+++ b/conftest.py
@@ -22,12 +22,14 @@ trd = defaultdict(dict)
 def read_command_line_args(config):
     os.environ["perf_config"] = config.option.perf_config
     os.environ["build_gramine"] = config.option.build_gramine
-    os.environ["commit_id"] = config.option.commit_id
+    os.environ["gramine_repo"] = config.option.gramine_repo
+    os.environ["gramine_commit"] = config.option.gramine_commit
+    os.environ["gsc_repo"] = config.option.gsc_repo
+    os.environ["gsc_commit"] = config.option.gsc_commit
     os.environ["iterations"] = config.option.iterations
     os.environ["exec_mode"] = config.option.exec_mode
     os.environ["EDMM"] = config.option.edmm
     os.environ["encryption"] = config.option.encryption
-    os.environ["curation_commit"] = config.option.curation_commit
     os.environ["tmpfs"] = config.option.tmpfs
     os.environ["jenkins_build_num"] = config.option.jenkins_build_num
 
@@ -70,7 +72,18 @@ def pytest_addoption(parser):
     print("\n##### In pytest_addoption #####\n")
     parser.addoption("--perf_config", action="store", type=str, default="baremetal", help="Bare-metal or Docker based execution.")
     parser.addoption("--build_gramine", action="store", type=str, default="source", help="Package or source based installation of Gramine.")
-    parser.addoption("--commit_id", action="store", type=str, default="", help="Any specific commit-id for source based installation.")
+    # *********** For baremetal workloads **************
+    # If 'gramine_commit' is passed, corresponding gramine commit will be checked out
+    # to build gramine from source. If 'gramine_commit' is not specified, latest
+    # master will be used to build gramine.
+    # ************** For container workloads **************
+    # If both 'gramine_commit' or 'gsc_commit' are not passed as parameters, v1.5 would be
+    # used as default for both commits.
+    # If 'gramine_commit' is master/any other commit, 'gsc_commit' must be passed as master.
+    parser.addoption("--gramine_repo", action="store", type=str, default="", help="Gramine repo to be used.")
+    parser.addoption("--gramine_commit", action="store", type=str, default="", help="Gramine commit/branch to be checked out.")
+    parser.addoption("--gsc_repo", action="store", type=str, default="", help="Gramine GSC repo to be used.")
+    parser.addoption("--gsc_commit", action="store", type=str, default="", help="Gramine GSC commit/branch to be checked out.")
     parser.addoption("--iterations", action="store", type=str, default='3', help="Number of times workload/benchmark app needs to be launched/executed.")
     # Following will be value of 'exec_mode' that would be expected by the framework.
     # For Redis workload: "native,gramine-direct,gramine-sgx-single-thread-non-exitless,gramine-sgx-diff-core-exitless"
@@ -79,12 +92,6 @@ def pytest_addoption(parser):
     parser.addoption("--edmm", action="store", type=str, default="0", help="EDMM mode")
     parser.addoption("--encryption", action="store", type=str, default='0', help="Enable encryption for model/s before workload command execution.")
     parser.addoption("--tmpfs", action="store", type=str, default='0', help="Use tmpfs path for DB.")
-    # Following option is applicable only for curated workloads, to use the right gramine binaries for executing the workload.
-    # If the following option is not provided at command line, we use binaries after building from latest tagged gramine
-    # and contrib versions (like v1.4, v1.5 etc).
-    # If any gramine specific commit-id is provided, we use the binaries after building from the specified commit-id.
-    # If 'master' is provided as value to below option in command line, we use the binaires after building from the latest Gramine commit.
-    parser.addoption("--curation_commit", action="store", type=str, default="", help="Any specific commit/master to be checked out for curated workloads.")
     # Following option is the build number of the 'gramerf_performance_banehmarking' Jenkins job.
     # This number is used within the filename of the final report generated for the workload.
     parser.addoption("--jenkins_build_num", action="store", type=str, default="", help="Build number of Jenkins CI perf job")

--- a/docker_benchmarking/curated_apps_lib.py
+++ b/docker_benchmarking/curated_apps_lib.py
@@ -45,7 +45,9 @@ def update_curation_verifier_scripts():
         update_gsc(os.environ["gsc_repo"], os.environ["gsc_commit"])
 
 
-def update_gramine_branch(gramine_repo=GRAMINE_DEFAULT_REPO, gramine_commit='v1.5'):
+def update_gramine_branch(gramine_repo='', gramine_commit=''):
+    if gramine_repo == '': gramine_repo = GRAMINE_DEFAULT_REPO
+    if gramine_commit == '': gramine_commit = 'v1.5'
     commit_str = f" && cd gramine && git checkout {gramine_commit} && cd .."
     copy_cmd = "cp config.yaml.template config.yaml"
     gramine_string = GRAMINE_DEPTH_STR + GRAMINE_DEFAULT_REPO


### PR DESCRIPTION
*********** For baremetal workloads **************
If 'gramine_commit' is passed, corresponding gramine commit will be checked out to build gramine from source.
If 'gramine_commit' is not specified, latest master will be used to build gramine.

************** For container workloads **************
If both 'gramine_commit' or 'gsc_commit' are not passed as parameters, v1.5 would be used as default for both commits.
If 'gramine_commit' is master/any other commit, 'gsc_commit' must be passed as master.